### PR TITLE
Dir will be created on save, not on setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ Using any plugin manager you like, here is how to use with lazy.nvim plugin mana
 require("lazy").setup({
   { 
     "RutaTang/spectacle.nvim",
-    config = function()
-        require("spectacle").setup{}
-    end,
     dependencies = {
         'nvim-lua/plenary.nvim',
         'nvim-telescope/telescope.nvim'

--- a/lua/spectacle/core/init.lua
+++ b/lua/spectacle/core/init.lua
@@ -20,6 +20,7 @@ local SpectacleSave = function()
             print("Session name cannot be empty")
             return
         end
+        util.create_dir_if_not_exists(".spectacle")
         -- form session file path
         local p = ".spectacle/" .. session_name .. ".vim"
         -- check if session name already exists
@@ -46,6 +47,7 @@ local SpectacleSaveAs = function()
         print("Session name cannot be empty")
         return
     end
+    util.create_dir_if_not_exists(".spectacle")
     local p = ".spectacle/" .. session_name .. ".vim"
     local session_exists = util.check_if_file_exists(p)
     if session_exists then

--- a/lua/spectacle/init.lua
+++ b/lua/spectacle/init.lua
@@ -1,13 +1,6 @@
 local core = require("spectacle.core")
-local util = require("spectacle.util")
-
-local setup = function(opts)
-    -- init session folder
-    util.create_dir_if_not_exists(".spectacle")
-end
 
 return {
-    setup = setup,
     SpectacleSave = core.SpectacleSave,
     SpectacleSaveAs = core.SpectacleSaveAs,
     SpectacleTelescope = core.SpectacleTelescope,


### PR DESCRIPTION
PR is related to: https://github.com/RutaTang/spectacle.nvim/issues/2
It implements the simpler solution. `.spectacle` dir will no longer be created on setup.
It will be created on save.

This prevents the file system cluttering.
Later, I might even go for the complicated solution I described in the issue.

I also removed the `setup` completely, since it should no longer be needed