### PR TITLE
option to save all sessions at one place to facilitate session restore from any directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ require("lazy").setup({
 
 ## Configuration
 
-So far only Configuration is to provide the path of the directory where your want to save all your session via passing **session_dir** in **opts**, otherwise leave it as blank table i.e. **opts = {}**, and it will save all the session into directory ".spectacle" at the current working directory of the working file.
+So far only Configuration is to provide the path of the directory where your want to save all your session via passing ```session_dir``` in ```opts```, otherwise leave it as blank table i.e. ```opts = {}```, and it will save all the session into directory **.spectacle** at the current working directory of the working file.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ require("lazy").setup({
 
 ## Configuration
 
-So far only Configuration is to provide the path of the directory where your want to save all your session via passing ```session_dir``` in ```opts```, otherwise leave it as blank table i.e. ```opts = {}```, and it will save all the session into directory **.spectacle** at the current working directory of the working file.
+So far only Configuration is to provide the path of the directory where your want to save all your session via passing ```session_dir``` in ```opts```, otherwise leave it as blank table i.e. ```opts = {}```, and it will save all the session into directory ```.spectacle``` at the current working directory of the working file.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ require("lazy").setup({
 
 ## Configuration
 
-So far only Configuration is to provide the path of the directory where your want to save all your session via passing ```session_dir``` in ```opts```, otherwise leave it as blank table i.e. ```opts = {}```, and it will save all the session into directory ```.spectacle``` at the current working directory of the working file.
+So far only Configuration is to provide the path of the directory where your want to save all your session via passing ```session_dir``` in ```opts```, otherwise leave it as blank table i.e. ```opts = {}```, and it will save the session into directory ```.spectacle``` at the current working directory of the working file.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -11,30 +11,34 @@ The plugin is designed for working with mutiple sessions. With it, you can easil
   <img src="./art/showcase.gif">
 </p>
 
-
 ## Installnation
 
 Using any plugin manager you like, here is how to use with lazy.nvim plugin manager:
 
 ```lua
 require("lazy").setup({
-  { 
+  {
     "RutaTang/spectacle.nvim",
     dependencies = {
         'nvim-lua/plenary.nvim',
         'nvim-telescope/telescope.nvim'
-    } 
+    }
+        opts = {session_dir = "/path/of/dir/where/you/want/to/save/all/sessions"}
   },
 })
 ```
 
+## Configuration
+
+So far only Configuration is to provide the path of the directory where your want to save all your session via passing **session_dir** in **opts**, otherwise leave it as blank table i.e. **opts = {}**, and it will save all the session into directory ".spectacle" at the current working directory of the working file.
+
 ## API
 
-| API | Description |
-|-----|-------------|
-|  `SpectacleSave()`   |      Save session       |
-| `SpectacleSaveAs()`     | Save current session as a new session             |
-| `SpectacleTelescope()` | Open a telescope picker to manage sessions, you can press `<CR>` to select a session, `r` to rename a session, and `d` to delete a session, (Be sure you are in normal mode)| 
+| API                    | Description                                                                                                                                                                  |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SpectacleSave()`      | Save session                                                                                                                                                                 |
+| `SpectacleSaveAs()`    | Save current session as a new session                                                                                                                                        |
+| `SpectacleTelescope()` | Open a telescope picker to manage sessions, you can press `<CR>` to select a session, `r` to rename a session, and `d` to delete a session, (Be sure you are in normal mode) |
 
 For example, you can call `SpectacleTelescope()` API like this:
 
@@ -51,4 +55,3 @@ vim.api.nvim_set_keymap("n", "<leader>t", "<cmd>:lua require('spectacle').Specta
 ## How it works
 
 It simply saves the session content generated from command `:mksession` to a folder named `.spectacle` stored in current working directory. The session file stored in `.spectacle` folder stands for a single session. Its name is the session name. For example, conisder you create a session named `default`, its session file `default.vim` will be stored in `.spectacle`.
-

--- a/lua/spectacle/core/init.lua
+++ b/lua/spectacle/core/init.lua
@@ -32,7 +32,7 @@ local SpectacleSave = function()
 			print("Session name cannot be empty")
 			return
 		end
-		util.create_dir_if_not_exists(".spectacle")
+		util.create_dir_if_not_exists(session_dir)
 		-- form session file path
 		local p = session_dir .. session_name .. ".vim"
 		-- check if session name already exists
@@ -59,7 +59,7 @@ local SpectacleSaveAs = function()
 		print("Session name cannot be empty")
 		return
 	end
-	util.create_dir_if_not_exists(".spectacle")
+	util.create_dir_if_not_exists(session_dir)
 	local p = session_dir .. session_name .. ".vim"
 	local session_exists = util.check_if_file_exists(p)
 	if session_exists then
@@ -113,7 +113,7 @@ end
 
 local SpectacleTelescope = function()
 	-- get all session names
-	local files = util.list_files_in_dir(".spectacle")
+	local files = util.list_files_in_dir(session_dir)
 	local results = {}
 	for _, file in ipairs(files) do
 		table.insert(results, util.get_file_basename(file))

--- a/lua/spectacle/core/init.lua
+++ b/lua/spectacle/core/init.lua
@@ -17,7 +17,6 @@ local setup = function(opts)
 	else
 		session_dir = ".spectacle/"
 	end
-  print(session_dir)
 end
 M.setup = setup
 

--- a/lua/spectacle/core/init.lua
+++ b/lua/spectacle/core/init.lua
@@ -17,6 +17,7 @@ local setup = function(opts)
 	else
 		session_dir = ".spectacle/"
 	end
+  print(session_dir)
 end
 M.setup = setup
 

--- a/lua/spectacle/core/init.lua
+++ b/lua/spectacle/core/init.lua
@@ -8,153 +8,163 @@ local conf = require("telescope.config").values
 local M = {}
 
 local loadFrom = "" -- load from which session
+local session_dir = "" -- path to save and load sessions
+
+-- TODO : to ensure opts.session_dir has file separator at end
+local setup = function(opts)
+	if opts.session_dir then
+		session_dir = opts.session_dir .. ".spectacle/"
+	else
+		session_dir = ".spectacle/"
+	end
+end
+M.setup = setup
 
 local SpectacleSave = function()
-    if loadFrom ~= "" then
-        local p = ".spectacle/" .. loadFrom .. ".vim"
-        vim.cmd("mksession! " .. p)
-    else
-        -- get user input for seesion name
-        local session_name = vim.fn.input("Session name: ")
-        if session_name == "" then
-            print("Session name cannot be empty")
-            return
-        end
-        util.create_dir_if_not_exists(".spectacle")
-        -- form session file path
-        local p = ".spectacle/" .. session_name .. ".vim"
-        -- check if session name already exists
-        local session_exists = util.check_if_file_exists(p)
-        if session_exists then
-            print("Session name already exists")
-        end
-        -- save session
-        vim.cmd("mksession! " .. p)
-        -- update loadFrom
-        loadFrom = session_name
+	if loadFrom ~= "" then
+		local p = session_dir .. loadFrom .. ".vim"
+		vim.cmd("mksession! " .. p)
+	else
+		-- get user input for seesion name
+		local session_name = vim.fn.input("Session name: ")
+		if session_name == "" then
+			print("Session name cannot be empty")
+			return
+		end
+		util.create_dir_if_not_exists(".spectacle")
+		-- form session file path
+		local p = session_dir .. session_name .. ".vim"
+		-- check if session name already exists
+		local session_exists = util.check_if_file_exists(p)
+		if session_exists then
+			print("Session name already exists")
+		end
+		-- save session
+		vim.cmd("mksession! " .. p)
+		-- update loadFrom
+		loadFrom = session_name
 
-        vim.cmd([[echo "\n"]])
-    end
-    -- print success message
-    vim.cmd([[echo ""]])
-    print("Session " .. loadFrom .. " saved")
+		vim.cmd([[echo "\n"]])
+	end
+	-- print success message
+	vim.cmd([[echo ""]])
+	print("Session " .. loadFrom .. " saved")
 end
 M.SpectacleSave = SpectacleSave
 
 local SpectacleSaveAs = function()
-    local session_name = vim.fn.input("Session name: ")
-    if session_name == "" then
-        print("Session name cannot be empty")
-        return
-    end
-    util.create_dir_if_not_exists(".spectacle")
-    local p = ".spectacle/" .. session_name .. ".vim"
-    local session_exists = util.check_if_file_exists(p)
-    if session_exists then
-        print("Session name already exists")
-        return
-    end
-    vim.cmd("mksession! " .. p)
-    -- print success message
-    vim.cmd([[echo "\n"]])
-    print("New Session created and saved as " .. session_name)
-    -- update loadFrom
-    loadFrom = session_name
+	local session_name = vim.fn.input("Session name: ")
+	if session_name == "" then
+		print("Session name cannot be empty")
+		return
+	end
+	util.create_dir_if_not_exists(".spectacle")
+	local p = session_dir .. session_name .. ".vim"
+	local session_exists = util.check_if_file_exists(p)
+	if session_exists then
+		print("Session name already exists")
+		return
+	end
+	vim.cmd("mksession! " .. p)
+	-- print success message
+	vim.cmd([[echo "\n"]])
+	print("New Session created and saved as " .. session_name)
+	-- update loadFrom
+	loadFrom = session_name
 end
 M.SpectacleSaveAs = SpectacleSaveAs
 
 local _load_session = function(session_name)
-    local p = ".spectacle/" .. session_name .. ".vim"
-    local session_exists = util.check_if_file_exists(p)
-    if not session_exists then
-        print("Session does not exist")
-        return
-    end
-    vim.cmd("source " .. p)
-    -- Update loadFrom
-    loadFrom = session_name
+	local p = session_dir .. session_name .. ".vim"
+	local session_exists = util.check_if_file_exists(p)
+	if not session_exists then
+		print("Session does not exist")
+		return
+	end
+	vim.cmd("source " .. p)
+	-- Update loadFrom
+	loadFrom = session_name
 end
 
 local _rename_session = function(seesion_name)
-    local new_name = vim.fn.input("New name: ")
-    if new_name == "" then
-        print("Session name cannot be empty")
-        return
-    end
-    local old_path = ".spectacle/" .. seesion_name .. ".vim"
-    local new_path = ".spectacle/" .. new_name .. ".vim"
-    local session_exists = util.check_if_file_exists(new_path)
-    if session_exists then
-        print("Session name already exists")
-        return
-    end
-    -- rename session
-    vim.loop.fs_rename(old_path, new_path)
-    -- print success message
-    vim.cmd([[echo "\n"]])
-    print("Session " .. seesion_name .. " renamed to " .. new_name)
-    -- update loadFrom
-    if loadFrom == seesion_name then
-        loadFrom = new_name
-    end
+	local new_name = vim.fn.input("New name: ")
+	if new_name == "" then
+		print("Session name cannot be empty")
+		return
+	end
+	local old_path = session_dir .. seesion_name .. ".vim"
+	local new_path = session_dir .. new_name .. ".vim"
+	local session_exists = util.check_if_file_exists(new_path)
+	if session_exists then
+		print("Session name already exists")
+		return
+	end
+	-- rename session
+	vim.loop.fs_rename(old_path, new_path)
+	-- print success message
+	vim.cmd([[echo "\n"]])
+	print("Session " .. seesion_name .. " renamed to " .. new_name)
+	-- update loadFrom
+	if loadFrom == seesion_name then
+		loadFrom = new_name
+	end
 end
 
 local SpectacleTelescope = function()
-    -- get all session names
-    local files = util.list_files_in_dir(".spectacle")
-    local results = {}
-    for _, file in ipairs(files) do
-        table.insert(results, util.get_file_basename(file))
-    end
-    -- create telescope picker
-    local sessions = function(opts)
-        opts = opts or {}
-        pickers
-            .new(opts, {
-                prompt_title = "Sessions",
-                finder = finders.new_table({
-                    results = results,
-                }),
-                sorter = conf.generic_sorter(opts),
-                attach_mappings = function(prompt_bufnr, map)
-                    -- load session on enter
-                    map("n", "<CR>", function()
-                        local selection = action_state.get_selected_entry()
-                        actions.close(prompt_bufnr)
-                        _load_session(selection.value)
-                    end)
-                    -- delete session on d
-                    map("n", "d", function()
-                        local selection = action_state.get_selected_entry()
-                        actions.close(prompt_bufnr)
-                        if loadFrom == selection.value then
-                            loadFrom = ""
-                        end
-                        local p = ".spectacle/" .. selection.value .. ".vim"
-                        local confirm = vim.fn.input("Delete " .. selection.value .. "? (y/N): ")
-                        if confirm ~= "y" then
-                            vim.cmd([[echo ""]])
-                            return
-                        end
-                        vim.loop.fs_unlink(p)
-                        vim.cmd([[echo "\n"]])
-                        print("Session deleted")
-                    end)
-                    -- rename session on r
-                    map("n", "r", function()
-                        local selection = action_state.get_selected_entry()
-                        actions.close(prompt_bufnr)
-                        _rename_session(selection.value)
-                    end)
-                    -- no action on enter in insert mode
-                    map("i", "<CR>", function()
-                    end)
-                    return true
-                end,
-            })
-            :find()
-    end
-    sessions(require("telescope.themes").get_dropdown({}))
+	-- get all session names
+	local files = util.list_files_in_dir(".spectacle")
+	local results = {}
+	for _, file in ipairs(files) do
+		table.insert(results, util.get_file_basename(file))
+	end
+	-- create telescope picker
+	local sessions = function(opts)
+		opts = opts or {}
+		pickers
+			.new(opts, {
+				prompt_title = "Sessions",
+				finder = finders.new_table({
+					results = results,
+				}),
+				sorter = conf.generic_sorter(opts),
+				attach_mappings = function(prompt_bufnr, map)
+					-- load session on enter
+					map("n", "<CR>", function()
+						local selection = action_state.get_selected_entry()
+						actions.close(prompt_bufnr)
+						_load_session(selection.value)
+					end)
+					-- delete session on d
+					map("n", "d", function()
+						local selection = action_state.get_selected_entry()
+						actions.close(prompt_bufnr)
+						if loadFrom == selection.value then
+							loadFrom = ""
+						end
+						local p = session_dir .. selection.value .. ".vim"
+						local confirm = vim.fn.input("Delete " .. selection.value .. "? (y/N): ")
+						if confirm ~= "y" then
+							vim.cmd([[echo ""]])
+							return
+						end
+						vim.loop.fs_unlink(p)
+						vim.cmd([[echo "\n"]])
+						print("Session deleted")
+					end)
+					-- rename session on r
+					map("n", "r", function()
+						local selection = action_state.get_selected_entry()
+						actions.close(prompt_bufnr)
+						_rename_session(selection.value)
+					end)
+					-- no action on enter in insert mode
+					map("i", "<CR>", function() end)
+					return true
+				end,
+			})
+			:find()
+	end
+	sessions(require("telescope.themes").get_dropdown({}))
 end
 M.SpectacleTelescope = SpectacleTelescope
 

--- a/lua/spectacle/init.lua
+++ b/lua/spectacle/init.lua
@@ -4,4 +4,6 @@ return {
     SpectacleSave = core.SpectacleSave,
     SpectacleSaveAs = core.SpectacleSaveAs,
     SpectacleTelescope = core.SpectacleTelescope,
+  -- setup function to set passed configs
+    setup = core.setup,
 }

--- a/lua/spectacle/init.lua
+++ b/lua/spectacle/init.lua
@@ -4,6 +4,6 @@ return {
     SpectacleSave = core.SpectacleSave,
     SpectacleSaveAs = core.SpectacleSaveAs,
     SpectacleTelescope = core.SpectacleTelescope,
-  -- setup function to set passed configs
+  -- setup function to set passed opts
     setup = core.setup,
 }


### PR DESCRIPTION
Hi, 
thanks for this plugin, if I have understood it right it is saving my session into the ```.spectacle``` directory at my ```pwd``` in Neovim, I want an option where if I give a path of the directory in plugin config basically in ```opts``` option of ```lazy``` plugin manager, then it should save all the sessions into that directory only.

Also, during restore it should only look into that directory to restore the session and thus give all sessions saved in that directory as options to restore the one we want.
If the directory is not passed in the ```opts``` field of ```lazy``` plugin manager, then it will follow its default behavior, i.e., to save sessions into ```.spectacle``` the directory.

I have tried to incorporate this feature into the plugin, and it is working on my end flawlessly.

I am newbie into Neovim and contribution to open-source, and thus you can expect bugs, please take a review over it and merge it if you think it's good to have this feature.